### PR TITLE
enable HMR for sketches by replacing dynamic import with import.meta.glob

### DIFF
--- a/src/routes/sketches.$sketchId.tsx
+++ b/src/routes/sketches.$sketchId.tsx
@@ -7,21 +7,26 @@ export const Route = createFileRoute('/sketches/$sketchId')({
   component: RouteComponent,
 })
 
+if (import.meta.hot) {
+  import.meta.hot.accept(() => {
+    window.location.reload()
+  })
+}
+
 function RouteComponent() {
   const { sketchId } = Route.useParams()
 
   const [module, setModule] = useState<any>({})
 
+  const sketches: Record<string, { default: () => any }> = import.meta.glob('../sketches/*.ts', { eager: true })
+
   useEffect(() => {
-    import(`../sketches/${sketchId}.ts`)
-      .then((module) => {
-        setModule({
-          colorNode: module.default,
-        })
-      })
-      .catch((error) => {
-        console.error('Failed to load shader:', error)
-      })
+    const mod = sketches[`../sketches/${sketchId}.ts`]
+    if (mod) {
+      setModule({ colorNode: mod.default })
+    } else {
+      console.error('Sketch not found:', sketchId)
+    }
   }, [sketchId])
 
   const ref = useRef<any>(null)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,7 +31,9 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "noImplicitAny": false,
-    "strictNullChecks": true
+    "strictNullChecks": true,
+
+    "types": ["vite/client"]
   },
   "include": ["src", "src/design", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
This PR fixes the folowing issue https://github.com/phobon/fragments-boilerplate/issues/1

What's changed:
- Replaced the dynamic import with: `const sketches = import.meta.glob('../sketches/*.ts', { eager: true })`
- Used the route param to look up the correct sketch module from the glob.
- Added the following to ensure page reloads
```js
if (import.meta.hot) {
  import.meta.hot.accept(() => {
    window.location.reload()
  })
}
```

Result: now when editing a sketch file, the page automatically reloads.